### PR TITLE
Add support for Stream webhooks

### DIFF
--- a/src/PostmarkEvents/ComplaintEvent.php
+++ b/src/PostmarkEvents/ComplaintEvent.php
@@ -9,12 +9,20 @@ class ComplaintEvent extends PostmarkEvent
 {
     public function canHandlePayload(): bool
     {
-        return $this->event === 'SpamComplaint';
+        if ($this->event === 'SpamComplaint') {
+            return true;
+        }
+
+        if ($this->event === 'SubscriptionChange' && ($this->payload['SuppressionReason'] ?? null) === 'SpamComplaint') {
+            return true;
+        }
+
+        return false;
     }
 
     public function handle(Send $send)
     {
-        $complainedAt = Carbon::parse($this->payload['BouncedAt']);
+        $complainedAt = Carbon::parse($this->payload['BouncedAt'] ?? $this->payload['ChangedAt']);
 
         $send->registerComplaint($complainedAt);
     }

--- a/src/PostmarkEvents/PermanentBounceEvent.php
+++ b/src/PostmarkEvents/PermanentBounceEvent.php
@@ -9,20 +9,20 @@ class PermanentBounceEvent extends PostmarkEvent
 {
     public function canHandlePayload(): bool
     {
-        if ($this->event !== 'Bounce') {
-            return false;
+        if ($this->event === 'Bounce' && $this->payload['Type'] === 'HardBounce') {
+            return true;
         }
 
-        if ($this->payload['Type'] !== 'HardBounce') {
-            return false;
+        if ($this->event === 'SubscriptionChange' && ($this->payload['SuppressionReason'] ?? null) === 'HardBounce') {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     public function handle(Send $send)
     {
-        $bouncedAt = Carbon::parse($this->payload['BouncedAt']);
+        $bouncedAt = Carbon::parse($this->payload['BouncedAt'] ?? $this->payload['ChangedAt']);
 
         $send->registerBounce($bouncedAt);
     }

--- a/tests/ProcessPostmarkWebhookJobTest.php
+++ b/tests/ProcessPostmarkWebhookJobTest.php
@@ -52,6 +52,20 @@ class ProcessPostmarkWebhookJobTest extends TestCase
     }
 
     /** @test */
+    public function it_processes_a_postmark_bounce_via_subscription_change_webhook_call()
+    {
+        $this->webhookCall->update(['payload' => $this->getStub('bounceViaSubscriptionChangeWebhookContent')]);
+        (new ProcessPostmarkWebhookJob($this->webhookCall))->handle();
+
+        $this->assertEquals(1, SendFeedbackItem::count());
+        tap(SendFeedbackItem::first(), function (SendFeedbackItem $sendFeedbackItem) {
+            $this->assertEquals(SendFeedbackType::BOUNCE, $sendFeedbackItem->type);
+            $this->assertEquals(Carbon::parse('2019-11-05T16:33:54.0Z'), $sendFeedbackItem->created_at);
+            $this->assertTrue($this->send->is($sendFeedbackItem->send));
+        });
+    }
+
+    /** @test */
     public function it_wil_not_process_a_postmark_soft_bounce_webhook_call()
     {
         $this->webhookCall->update(['payload' => $this->getStub('softBounceWebhookContent')]);
@@ -64,6 +78,20 @@ class ProcessPostmarkWebhookJobTest extends TestCase
     public function it_processes_a_postmark_complaint_webhook_call()
     {
         $this->webhookCall->update(['payload' => $this->getStub('complaintWebhookContent')]);
+        (new ProcessPostmarkWebhookJob($this->webhookCall))->handle();
+
+        $this->assertEquals(1, SendFeedbackItem::count());
+        tap(SendFeedbackItem::first(), function (SendFeedbackItem $sendFeedbackItem) {
+            $this->assertEquals(SendFeedbackType::COMPLAINT, $sendFeedbackItem->type);
+            $this->assertEquals(Carbon::parse('2019-11-05T16:33:54.0Z'), $sendFeedbackItem->created_at);
+            $this->assertTrue($this->send->is($sendFeedbackItem->send));
+        });
+    }
+
+    /** @test */
+    public function it_processes_a_postmark_complaint_via_subscription_change_webhook_call()
+    {
+        $this->webhookCall->update(['payload' => $this->getStub('complaintViaSubscriptionChangeWebhookContent')]);
         (new ProcessPostmarkWebhookJob($this->webhookCall))->handle();
 
         $this->assertEquals(1, SendFeedbackItem::count());

--- a/tests/stubs/bounceViaSubscriptionChangeWebhookContent.json
+++ b/tests/stubs/bounceViaSubscriptionChangeWebhookContent.json
@@ -1,0 +1,15 @@
+{
+  "RecordType":"SubscriptionChange",
+  "ServerID":123456,
+  "MessageStream": "outbound",
+  "ChangedAt": "2019-11-05T16:33:54.9070259Z",
+  "Recipient": "bounced-address@wildbit.com",
+  "Origin": "Recipient",
+  "SuppressSending": true,
+  "SuppressionReason": "HardBounce",
+  "Tag": "my-tag",
+  "MessageID": "20130503192659.13651.20287@mg.craftremote.com",
+  "Metadata" : {
+      "send-uuid" : "my-uuid"
+  }
+}

--- a/tests/stubs/complaintViaSubscriptionChangeWebhookContent.json
+++ b/tests/stubs/complaintViaSubscriptionChangeWebhookContent.json
@@ -1,0 +1,15 @@
+{
+  "RecordType":"SubscriptionChange",
+  "ServerID":123456,
+  "MessageStream": "outbound",
+  "ChangedAt": "2019-11-05T16:33:54.9070259Z",
+  "Recipient": "bounced-address@wildbit.com",
+  "Origin": "Recipient",
+  "SuppressSending": true,
+  "SuppressionReason": "SpamComplaint",
+  "Tag": "my-tag",
+  "MessageID": "20130503192659.13651.20287@mg.craftremote.com",
+  "Metadata" : {
+      "send-uuid" : "my-uuid"
+  }
+}


### PR DESCRIPTION
# Description
As Postmark officially launched [Message Streams](https://postmarkapp.com/message-streams), it is necessary to support the `SubscriptionChange` webhook event to handle `HardBounce` and `SpamComplaint` events to comply with their usage terms. 

This pull request adds support for both events. 

# Related issues
This addresses issue #7 

# Tests
 It seems like GitHub cannot run actions on private repository dependencies, but all relevant tests have been added and passed.

![image](https://user-images.githubusercontent.com/31487237/94354229-18949200-0047-11eb-969f-ac5689e7baa2.png)
